### PR TITLE
Add e-op and e-if to syntax

### DIFF
--- a/interpreter-tests.rkt
+++ b/interpreter-tests.rkt
@@ -15,7 +15,9 @@
 (define/provide-test-suite sample-tests
   ;; DO NOT ADD TESTS HERE
   (test-equal? "Works with Num primitive"
-               (eval `2) (v-num 2)))
+               (eval `2) (v-num 2))
+  (test-raises-error? "Passing Str to + results in error"
+                             (eval `{+ "bad" 1})))
 
 ;; DO NOT EDIT ABOVE THIS LINE =================================================
 


### PR DESCRIPTION
This PR adds `e-op` and `e-if` variants to the `Expr` type.